### PR TITLE
Don't hyphenate HTML entities

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,13 @@ function gulpHypher(hyphenation_pattern) {
   }
   var h = new hypher(hyphenation_pattern);
   var hyphenateText = function(text) {
-    return h.hyphenateText(text);
+    // split the text in html entity and not entity
+    return text.split(/(!?&[a-zA-Z]*;)/).map((textPart) => {
+      // immediately return html entities and hyphenate everything else
+      return textPart.match(/&[a-zA-Z]*;/)
+        ? textPart
+        : h.hyphenateText(textPart);
+    }).join('');
   };
 
   return through.obj(function (file, enc, cb) {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Preprocess HTML with Hypher",
   "main": "index.js",
   "scripts": {
-    "test": "./node_modules/.bin/mocha tests/*"
+    "test": "./node_modules/.bin/mocha tests.js*"
   },
   "repository": {
     "type": "git",

--- a/tests.js
+++ b/tests.js
@@ -11,8 +11,12 @@ var hyphenation_pattern = require('hyphenation.en-gb');
 describe('gulp-hypher', function() {
 	it('should ', function (cb) {
 		var stream = gulpHypher(hyphenation_pattern);
-		var html = '<p>Council leaders have called on the government to provide more resources to help them house extra refugees that the UK is planning to accept.</p>';
-		var result = '<p>Coun\u00ADcil lead\u00ADers have called on the gov\u00ADern\u00ADment to provide more re\u00ADsources to help them house ex\u00ADtra refugees that the UK is plan\u00ADning to ac\u00ADcept.</p>';
+		var html = '<p>Council leaders have called on the government to provide more resources to help them house extra refugees that the UK is planning to accept.</p>'
+			+ '<p>... and then I just test if it also works with HTML entities</p>'
+			+ '<p>dagger -> &dagger; <br>kappa -> &kappa; <br>omicron -> &omicron; </p>';
+		var result = '<p>Coun\u00ADcil lead\u00ADers have called on the gov\u00ADern\u00ADment to provide more re\u00ADsources to help them house ex\u00ADtra refugees that the UK is plan\u00ADning to ac\u00ADcept.</p>'
+			+ '<p>... and then I just test if it also works with HTML en\u00ADtit\u00ADies</p>'
+			+ '<p>dag\u00ADger -> &dagger; <br>kappa -> &kappa; <br>omic\u00ADron -> &omicron; </p>';
 		var file = new gutil.File({
 			base: __dirname,
 			path: __dirname + '/test.html',


### PR DESCRIPTION
The hypher destroyed HTML entities by changing for example `&dagger;` to `&dag\u00ADger;`
